### PR TITLE
Check if bot is connected to chat and add OnMessage handler if needed

### DIFF
--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -83,9 +83,11 @@ namespace LiveSplit.SplitsBet
                 thread.Join();
             }
             
-            //TODO Check if bot is already connected (In case SplitsBet is added, removed and readded)
-            Twitch.Instance.ConnectToChat(Twitch.Instance.ChannelName);
-            Twitch.Instance.Chat.OnMessage += OnMessage;
+            if (!Twitch.Instance.ConnectedChats.ContainsKey(Twitch.Instance.ChannelName))
+            {
+                Twitch.Instance.ConnectToChat(Twitch.Instance.ChannelName);
+                Twitch.Instance.Chat.OnMessage += OnMessage;
+            }
         }
 
         #endregion

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -89,8 +89,7 @@ namespace LiveSplit.SplitsBet
                 Twitch.Instance.ConnectToChat(Twitch.Instance.ChannelName);
             }
 
-            Delegate[] onMessageHandlers = Twitch.Instance.Chat.OnMessage.GetInvocationList();
-            if (!onMessageHandlers.Contains((Action<object, TwitchChat.Message>) OnMessage))
+            if (!Twitch.Instance.Chat.OnMessage.GetInvocationList().Contains((Action<object, TwitchChat.Message>) OnMessage))
             {
                 Twitch.Instance.Chat.OnMessage += OnMessage;
             }

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LiveSplit.TimeFormatters;
+using System.Windows.Forms;
 
 namespace LiveSplit.SplitsBet
 {
@@ -86,6 +87,11 @@ namespace LiveSplit.SplitsBet
             if (!Twitch.Instance.ConnectedChats.ContainsKey(Twitch.Instance.ChannelName))
             {
                 Twitch.Instance.ConnectToChat(Twitch.Instance.ChannelName);
+            }
+
+            Delegate[] onMessageHandlers = Twitch.Instance.Chat.OnMessage.GetInvocationList();
+            if (!onMessageHandlers.Contains((Action<object, TwitchChat.Message>) OnMessage))
+            {
                 Twitch.Instance.Chat.OnMessage += OnMessage;
             }
         }


### PR DESCRIPTION
If it is already connected to the TwitchChat instance of the channel (either due to another bot or due to a restart of the component), simply use the current chat instance instead of re-connecting.

If the current TwitchChat doesn't contain the OnMessage delegate (due to a fresh SplitsBet instance), add it.
