### PR TITLE
Create copied score dictionaries instead of re-referencing

### DIFF
--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -247,7 +247,7 @@ namespace LiveSplit.SplitsBet
             Time Segment = State.CurrentTime - SegmentBeginning;
             var timeFormatter = new ShortTimeFormatter();
             Twitch.Instance.Chat.SendMessage("/me Time for this split was " + timeFormatter.Format(Segment.RealTime));
-            Scores[State.CurrentSplitIndex - 1] = State.CurrentSplitIndex > 1 ? Scores[State.CurrentSplitIndex - 2] : new Dictionary<string, int>();
+            Scores[State.CurrentSplitIndex - 1] = State.CurrentSplitIndex > 1 ? new Dictionary<string, int>(Scores[State.CurrentSplitIndex - 2]) : new Dictionary<string, int>();
             foreach (KeyValuePair<string, Tuple<TimeSpan, double>> entry in Bets[State.CurrentSplitIndex - 1])
             {
                 if (Scores[State.CurrentSplitIndex - 1].ContainsKey(entry.Key))
@@ -280,7 +280,7 @@ namespace LiveSplit.SplitsBet
 
         private void CopyScore(object sender, EventArgs e)
         {
-            Scores[State.CurrentSplitIndex - 1] = Scores[State.CurrentSplitIndex - 2];
+            Scores[State.CurrentSplitIndex - 1] = new Dictionary<string, int>(Scores[State.CurrentSplitIndex - 2]);
             Bets[State.CurrentSplitIndex] = new Dictionary<string, Tuple<TimeSpan, double>>();
         }
 

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -246,7 +246,7 @@ namespace LiveSplit.SplitsBet
         {
             var segment = State.CurrentTime - SegmentBeginning;
             var timeFormatter = new ShortTimeFormatter();
-            Twitch.Instance.Chat.SendMessage("/me Time for this split was " + timeFormatter.Format(Segment.RealTime));
+            Twitch.Instance.Chat.SendMessage("/me Time for this split was " + timeFormatter.Format(segment.RealTime));
             Scores[State.CurrentSplitIndex - 1] = State.CurrentSplitIndex > 1 ? new Dictionary<string, int>(Scores[State.CurrentSplitIndex - 2]) : new Dictionary<string, int>();
             foreach (KeyValuePair<string, Tuple<TimeSpan, double>> entry in Bets[State.CurrentSplitIndex - 1])
             {


### PR DESCRIPTION
Re-referencing to the old dictionaries would cause problems with the delta-score.
