### PR TITLE
Dispose the OnMessage Event Handler

### DIFF
--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -97,7 +97,6 @@ namespace LiveSplit.SplitsBet
             }
 
             Twitch.Instance.Chat.OnMessage += OnMessage;
-
         }
 
         #endregion
@@ -389,6 +388,7 @@ namespace LiveSplit.SplitsBet
 
         public override void Dispose()
         {
+            Twitch.Instance.Chat.OnMessage -= OnMessage;
         }
 
         #endregion


### PR DESCRIPTION
The OnMessage Event Handler needs to be disposed when the component is not used anymore in order to make sure the Event Handler is not called anymore.
