### PR TITLE
Special Bets should be Prefixed

### DIFF
--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -137,7 +137,7 @@ namespace LiveSplit.SplitsBet
 
             try
             {
-                if (argument.ToLower().Contains("kappa"))
+                if (argument.ToLower().StartsWith("kappa"))
                 {
                     argument = "4:20.69";
                     SendMessage(user.Name + " bet 4:20.69 Kappa");


### PR DESCRIPTION
!bet 4:20 Kappa. Enough said lol

Special bets should be prefixed by the bet name, NOT with contains. Just for reliability issues.

Future Implementations: dictionary of special bet types. For now, leave as-is.
