### PR TITLE
Update the update XML URL

### DIFF
--- a/SplitsBetFactory.cs
+++ b/SplitsBetFactory.cs
@@ -39,7 +39,7 @@ namespace LiveSplit.SplitsBet
 
         public string UpdateURL
         {
-            get { return "http://livesplit.org/update/"; }
+            get { return "http://fezmod.tk/files/travis/splitsbet/update/"; }//TODO move away from FEZMod..?
         }
 
         public Version Version
@@ -49,7 +49,7 @@ namespace LiveSplit.SplitsBet
 
         public string XMLURL
         {
-            get { return "http://livesplit.org/update/Components/LiveSplit.Remote.xml"; }
+            get { return UpdateURL + "Components/LiveSplit.SplitsBet.xml"; }
         }
     }
 }


### PR DESCRIPTION
Requires testing and confirmation.

Sidenotes:
I could set up Travis to automatically push an update to the Components directory as soon as a build with a specific tag (f.e. "release-v0.2") gets built. I don't think it would fit into an issue here.
Also, the current URL is suboptimal, but it's ok during the time SplitsBet has got no domain / website on its own. It's just that it's somewhat weird.

Should fix #36.
