### PR TITLE
Support custom comparisons and fix a calculation error

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -66,7 +66,8 @@ namespace LiveSplit.SplitsBet
             txtMinBetTime.Text = Formatter.Format(MinimumTime);
             cmbTimeToShow.Items.Clear();
             cmbTimeToShow.Items.AddRange(LivesplitState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName).ToArray());
-            
+            if (!cmbTimeToShow.Items.Contains(TimeToShow))
+                cmbTimeToShow.Items.Add(TimeToShow);
         }
 
         public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)

--- a/Settings.cs
+++ b/Settings.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using LiveSplit.Model;
 using System.Xml;
 using LiveSplit.TimeFormatters;
+using LiveSplit.Model.Comparisons;
 
 namespace LiveSplit.SplitsBet
 {
@@ -49,7 +50,6 @@ namespace LiveSplit.SplitsBet
 
             chkCancelBets.DataBindings.Add("Checked", this, "CanUnBet", false, DataSourceUpdateMode.OnPropertyChanged);
             txtCancelingPenalty.DataBindings.Add("Text", this, "UnBetPenalty", false, DataSourceUpdateMode.OnPropertyChanged);
-            //txtMinBetTime.DataBindings.Add("Text", this, "MinimumTimeText", false, DataSourceUpdateMode.OnPropertyChanged);
             numScores.DataBindings.Add("Value", this, "NbScores", false, DataSourceUpdateMode.OnPropertyChanged);
             chkGlobalTime.DataBindings.Add("Checked", this, "UseGlobalTime", false, DataSourceUpdateMode.OnPropertyChanged);
             cmbTimingMethod.DataBindings.Add("SelectedItem", this, "OverridenTimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -64,6 +64,9 @@ namespace LiveSplit.SplitsBet
         void Settings_Load(object sender, EventArgs e)
         {
             txtMinBetTime.Text = Formatter.Format(MinimumTime);
+            cmbTimeToShow.Items.Clear();
+            cmbTimeToShow.Items.AddRange(LivesplitState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName).ToArray());
+            
         }
 
         public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)

--- a/Settings.designer.cs
+++ b/Settings.designer.cs
@@ -280,12 +280,6 @@
             // 
             this.cmbTimeToShow.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.cmbTimeToShow.FormattingEnabled = true;
-            this.cmbTimeToShow.Items.AddRange(new object[] {
-            "Personal Best",
-            "Best Segments",
-            "Best Split Times",
-            "Average Segments",
-            "None"});
             this.cmbTimeToShow.Location = new System.Drawing.Point(202, 257);
             this.cmbTimeToShow.Name = "cmbTimeToShow";
             this.cmbTimeToShow.Size = new System.Drawing.Size(120, 21);

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using LiveSplit.TimeFormatters;
 using System.Windows.Forms;
 using System.ComponentModel;
+using LiveSplit.Model.Comparisons;
 
 namespace LiveSplit.SplitsBet
 {
@@ -111,24 +112,9 @@ namespace LiveSplit.SplitsBet
                 var timeFormatter = new ShortTimeFormatter();
                 var timeFormatted = timeFormatter.Format(GetTime(State.CurrentSplit.Comparisons[Settings.TimeToShow]));
                 string ret = "Place your bets for " + State.CurrentSplit.Name + "! ";
-                if (TimeSpanParser.Parse(timeFormatted) > TimeSpan.Zero)
+                if (TimeSpanParser.Parse(timeFormatted) > TimeSpan.Zero && Settings.TimeToShow != "None")
                 {
-                    switch (Settings.TimeToShow)
-                    {
-                        case "Personal Best":
-                            ret += "PB segment for this split is " + timeFormatted + " ";
-                            break;
-                        case "Best Segments":
-                            ret += "Best segment for this split is " + timeFormatted + " ";
-                            break;
-                        case "Best Split Times":
-                            ret += "Best splits segment time for this split is " + timeFormatted + " ";
-                            break;
-                        case "Average Segments":
-                            ret += "Average segment for this split is " + timeFormatted + " ";
-                            break;
-                        // If "None" is selected, no need to show a message
-                    }
+                    ret += CompositeComparisons.GetShortComparisonName(Settings.TimeToShow.ToString()) + " segment for this split is " + timeFormatted + " ";
                 }
                 if (Settings.UseGlobalTime) ret += "And remember that global time is used to bet!";
 

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -17,6 +17,7 @@ using LiveSplit.TimeFormatters;
 using System.Windows.Forms;
 using System.ComponentModel;
 using LiveSplit.Model.Comparisons;
+using LiveSplit.UI;
 
 namespace LiveSplit.SplitsBet
 {
@@ -56,6 +57,7 @@ namespace LiveSplit.SplitsBet
             };
             Commands = new Dictionary<string, Action<TwitchChat.User, string>>();
             State = state;
+            State.ComparisonRenamed += State_ComparisonRenamed;
             SpecialBets = new Dictionary<string, TimeSpan>();
             ActiveSpecialBets = false;
             EndOfRun = false;
@@ -511,6 +513,16 @@ namespace LiveSplit.SplitsBet
         #endregion
 
         #region Events
+
+        void State_ComparisonRenamed(object sender, EventArgs e)
+        {
+            var args = (RenameEventArgs)e;
+            if (Settings.TimeToShow == args.OldName)
+            {
+                Settings.TimeToShow = args.NewName;
+                ((LiveSplitState)sender).Layout.HasChanged = true;
+            }
+        }
 
         private void OnMessage(object sender, TwitchChat.Message message)
         {

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -110,14 +110,15 @@ namespace LiveSplit.SplitsBet
                 SegmentBeginning[State.CurrentSplitIndex] = State.CurrentTime;
                 Bets[State.CurrentSplitIndex] = new Dictionary<string, Tuple<TimeSpan, double>>();
                 var timeFormatter = new ShortTimeFormatter();
+                var comparison = State.Run.Comparisons.Contains(Settings.TimeToShow) ? Settings.TimeToShow : Run.PersonalBestComparisonName;
                 var previousTime = State.CurrentSplitIndex > 0 
-                    ? GetTime(State.Run[State.CurrentSplitIndex - 1].Comparisons[Settings.TimeToShow]) 
+                    ? GetTime(State.Run[State.CurrentSplitIndex - 1].Comparisons[comparison]) 
                     : TimeSpan.Zero;
-                var timeFormatted = timeFormatter.Format(GetTime(State.CurrentSplit.Comparisons[Settings.TimeToShow]) - previousTime);
+                var timeFormatted = timeFormatter.Format(GetTime(State.CurrentSplit.Comparisons[comparison]) - previousTime);
                 string ret = "Place your bets for " + State.CurrentSplit.Name + "! ";
-                if (TimeSpanParser.Parse(timeFormatted) > TimeSpan.Zero && Settings.TimeToShow != "None")
+                if (TimeSpanParser.Parse(timeFormatted) > TimeSpan.Zero && comparison != "None")
                 {
-                    ret += CompositeComparisons.GetShortComparisonName(Settings.TimeToShow.ToString()) + " segment for this split is " + timeFormatted + " ";
+                    ret += CompositeComparisons.GetShortComparisonName(comparison) + " segment for this split is " + timeFormatted + " ";
                 }
                 if (Settings.UseGlobalTime) ret += "And remember that global time is used to bet!";
 

--- a/SplitsBetComponent.cs
+++ b/SplitsBetComponent.cs
@@ -109,7 +109,10 @@ namespace LiveSplit.SplitsBet
                 SegmentBeginning[State.CurrentSplitIndex] = State.CurrentTime;
                 Bets[State.CurrentSplitIndex] = new Dictionary<string, Tuple<TimeSpan, double>>();
                 var timeFormatter = new ShortTimeFormatter();
-                var timeFormatted = timeFormatter.Format(GetTime(State.CurrentSplit.Comparisons[Settings.TimeToShow]));
+                var previousTime = State.CurrentSplitIndex > 0 
+                    ? GetTime(State.Run[State.CurrentSplitIndex - 1].Comparisons[Settings.TimeToShow]) 
+                    : TimeSpan.Zero;
+                var timeFormatted = timeFormatter.Format(GetTime(State.CurrentSplit.Comparisons[Settings.TimeToShow]) - previousTime);
                 string ret = "Place your bets for " + State.CurrentSplit.Name + "! ";
                 if (TimeSpanParser.Parse(timeFormatted) > TimeSpan.Zero)
                 {


### PR DESCRIPTION
Comparisons(Settings.TimeToShow) gives you the split time. What you really want is the segment time.

This should fix https://github.com/Gyoo/LiveSplit.SplitsBet/issues/53
